### PR TITLE
Swap menu item order to correctly reflect labels.

### DIFF
--- a/src/components/Researcher/ParticipantList/AddButton.tsx
+++ b/src/components/Researcher/ParticipantList/AddButton.tsx
@@ -163,8 +163,7 @@ export default function AddButton({ researcher, studies, setUpdateCount, setPart
           <MenuItem
             onClick={() => {
               setPopover(null)
-              setAddStudy(false)
-              setAddParticipantStudy(true)
+              setAddStudy(true)
             }}
           >
             <Typography variant="h6">{t("Add a new study")}</Typography>
@@ -173,7 +172,8 @@ export default function AddButton({ researcher, studies, setUpdateCount, setPart
           <MenuItem
             onClick={() => {
               setPopover(null)
-              setAddStudy(true)
+              setAddStudy(false)
+              setAddParticipantStudy(true)
             }}
           >
             <Typography variant="h6">{t("Add a new patient and study.")}</Typography>


### PR DESCRIPTION
@sarithapillai8 The `Add a new group` and `Add a new user and group` options are currently flipped, and that was not fixed. This PR fixes the issue.