### PR TITLE
Fixed Issue #371 Activities selected move around after moving to next page

### DIFF
--- a/src/components/Researcher/ActivityList/Index.tsx
+++ b/src/components/Researcher/ActivityList/Index.tsx
@@ -134,7 +134,7 @@ export default function ActivityList({
                 result = result.concat(activitiesData)
                 setActivities(sortData(result, selectedData, "name"))
               }
-              setPaginatedActivities(result.slice(0, rowCount))
+              setPaginatedActivities(sortData(result, selectedData, "name").slice(0, rowCount))
               setPage(0)
             } else {
               if (result.length === 0) setActivities([])

--- a/src/components/Researcher/ParticipantList/Index.tsx
+++ b/src/components/Researcher/ParticipantList/Index.tsx
@@ -184,7 +184,7 @@ export default function ParticipantList({
                 setParticipants(sortData(result, selectedData, "id"))
               }
               result = sortData(result, selectedData, "id")
-              setPaginatedParticipants(result.slice(0, rowCount))
+              setPaginatedParticipants(sortData(result, selectedData, "id").slice(0, rowCount))
               setPage(0)
             } else {
               if (result.length === 0) setParticipants([])

--- a/src/components/Researcher/SensorsList/Index.tsx
+++ b/src/components/Researcher/SensorsList/Index.tsx
@@ -106,7 +106,7 @@ export default function SensorsList({
                 result = result.concat(sensorData)
                 setSensors(sortData(result, selectedData, "name"))
               }
-              setPaginatedSensors(result.slice(0, rowCount))
+              setPaginatedSensors(sortData(result, selectedData, "name").slice(0, rowCount))
               setPage(0)
             } else {
               if (result.length === 0) setSensors([])


### PR DESCRIPTION
Fixed [**Issue #371**](https://github.com/BIDMCDigitalPsychiatry/LAMP-platform/issues/371)     Activities selected move around after moving to next page

