### PR TITLE
Alphabetize data portal tree

### DIFF
--- a/src/components/data_portal/DataPortalShared.tsx
+++ b/src/components/data_portal/DataPortalShared.tsx
@@ -277,7 +277,6 @@ export function formatGraphName(tagName) {
 }
 
 export function formatTagName(tagName, returnCategoryOnly = true) {
-  console.log(tagName)
   let categoryIndex = tagName.lastIndexOf(".")
   let newName = tagName
     .split(".")

--- a/src/components/data_portal/QueryBuilder.tsx
+++ b/src/components/data_portal/QueryBuilder.tsx
@@ -2,23 +2,17 @@ import React from "react"
 import {
   Typography,
   Card,
-  Select,
-  FormControl,
   FormControlLabel,
   FormGroup,
   Switch,
   Button,
-  InputLabel,
-  MenuItem,
   Checkbox,
   Container,
-  Input,
   Icon,
   Backdrop,
   makeStyles,
   CardHeader,
   Box,
-  IconButton,
 } from "@material-ui/core"
 import { tagged_entities, ajaxRequest, formatGraphName, formatTagName } from "./DataPortalShared"
 import { useDrop } from "react-dnd"
@@ -232,7 +226,6 @@ export default function QueryBuilder(props) {
             <Box className={classes.tagsBox}>
               {returnSortedTagObject(props.tagObject[category]).map((array) => {
                 //let's format the names
-                console.log(array)
                 let printedName = formatGraphName(array[0])
                 return (
                   <Card key={array[1]} className={classes.tagCard}>
@@ -425,7 +418,6 @@ export default function QueryBuilder(props) {
         <Box className={classes.tagsBox}>
           {returnSortedTags(props.availableSharedTags).map((name) => {
             //let's format the names
-            console.log(name)
             let printedName = formatGraphName(name)
             return (
               <Card key={name} className={classes.tagCard}>

--- a/src/components/data_portal/RenderTree.tsx
+++ b/src/components/data_portal/RenderTree.tsx
@@ -31,7 +31,6 @@ export default function RenderTree({ id, type, token, name, onSetQuery, onUpdate
   )
   const [alphabetizedTree, setAlphabetizedTree] = React.useState(null)
   function alphabetizeTree(array) {
-    console.log(array)
     if (!Array.isArray(array) || array.length === 1) return array
     let res = array.slice().sort((a, b) => (a.name ? a.name : a.id).localeCompare(b.name ? b.name : b.id))
     return res
@@ -148,14 +147,12 @@ export default function RenderTree({ id, type, token, name, onSetQuery, onUpdate
   if (type === "Administrator") {
     React.useEffect(() => {
       if (!expanded) return
-      //console.log("Getting admin options")
       setTree(tags_object[type])
     }, [expanded])
   } else if (Object.keys(tags_object).includes(id[id.length - 1])) {
     //then call the api
     React.useEffect(() => {
       if (!expanded) return
-      //console.log(`Calling API to show array of ${id[id.length - 1]}`)
       let testQuery =
         id[id.length - 1] === "Researcher"
           ? `$LAMP.Researcher.list()`
@@ -242,15 +239,13 @@ export default function RenderTree({ id, type, token, name, onSetQuery, onUpdate
                 onClick={() => {
                   navigator.clipboard
                     .writeText(id[id.length - 1])
-                    .then((res) => {
-                      console.log(res)
+                    .then(() => {
                       setCopyText("Copied!")
                       setTimeout(() => {
                         setCopyText(`Copy ${id[id.length - 2]} ID to clipboard`)
                       }, 5000)
                     })
-                    .catch((res) => {
-                      console.log(res)
+                    .catch(() => {
                       setCopyText("Unable to copy!")
                       setTimeout(() => {
                         setCopyText(`Copy ${id[id.length - 2]} ID to clipboard`)


### PR DESCRIPTION
This PR adds additional UI functionality to the data portal. Updates include:

- Researchers, Studies, and Users are now alphabetized by name by default (or id if no name is available). This feature can be turned off to return to the original order, which is sorted by creation date.
- A button has been added to allow users to copy ids from the tree
- The dropdown box for tag selection has been entirely overhauled for better visibility. Tags now appear as boxes, again in alphabetical order for ease of use.
- Users now have their alias displayed in the tree, if one has been created for them.