### PR TITLE
Remove LAMP Community option from Dashboard Help Menu

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -244,15 +244,6 @@ export default function Login({ setIdentity, lastDomain, onComplete, ...props })
               dense
               onClick={() => {
                 setHelpMenu(undefined)
-                window.open("https://community.lamp.digital", "_blank")
-              }}
-            >
-              <b style={{ color: colors.grey["600"] }}>LAMP {`${t("Community")}`}</b>
-            </MenuItem>
-            <MenuItem
-              dense
-              onClick={() => {
-                setHelpMenu(undefined)
                 window.open("mailto:team@digitalpsych.org", "_blank")
               }}
             >

--- a/src/components/NavigationLayout.tsx
+++ b/src/components/NavigationLayout.tsx
@@ -434,15 +434,6 @@ export default function NavigationLayout({
                       dense
                       onClick={() => {
                         setShowCustomizeMenu(undefined)
-                        window.open("https://community.lamp.digital", "_blank")
-                      }}
-                    >
-                      {`${t("LAMP Community")}`}
-                    </MenuItem>
-                    <MenuItem
-                      dense
-                      onClick={() => {
-                        setShowCustomizeMenu(undefined)
                         window.open("mailto:team@digitalpsych.org", "_blank")
                       }}
                     >
@@ -578,15 +569,6 @@ export default function NavigationLayout({
                       }}
                     >
                       <b style={{ color: colors.grey["600"] }}>{`${t("Help & Support")}`}</b>
-                    </MenuItem>
-                    <MenuItem
-                      dense
-                      onClick={() => {
-                        setShowCustomizeMenu(undefined)
-                        window.open("https://community.lamp.digital", "_blank")
-                      }}
-                    >
-                      <b style={{ color: colors.grey["600"] }}>{`${t("LAMP Community")}`}</b>
                     </MenuItem>
                     <MenuItem
                       dense


### PR DESCRIPTION
Recently the LAMP Forum was archived due to lack of use. However our dashboard still contained a LAMP Community option in the help menu which now points at a dead link. This is a first pass PR to remove references to the Forum from the dashboard.