### PR TITLE
Fix alias passing

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -858,7 +858,11 @@ function AppRouter({ ...props }) {
                 authType={state.authType}
                 id={props.match.params.id}
                 title={`User ${getParticipant(props.match.params.id).id}`}
-                name={`${getParticipant(props.match.params.id).name}`}
+                name={
+                  getParticipant(props.match.params.id)?.alias ||
+                  getParticipant(props.match.params.id)?.name ||
+                  getParticipant(props.match.params.id)?.id
+                }
                 goBack={props.history.goBack}
                 onLogout={() => reset()}
                 activeTab={state.activeTab}


### PR DESCRIPTION
`participant.name` did not work the way I expected. Updating it to use the alias.