### PR TITLE
Login Password Visibility Toggle Formatting Fix

### DIFF
--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -58,6 +58,7 @@ const useStyles = makeStyles((theme: Theme) =>
     textfieldStyle: {
       "& input": { backgroundColor: "#f5f5f5", borderRadius: 10 },
       "& fieldset": { border: 0 },
+      "& .MuiInputBase-inputAdornedEnd": { paddingRight: 48 },
     },
     buttonNav: {
       "& button": { width: 200, "& span": { textTransform: "capitalize", fontSize: 16, fontWeight: "bold" } },


### PR DESCRIPTION
Adding proper padding: Added "& .MuiInputBase-inputAdornedEnd": { paddingRight: 48 } to the textfieldStyle class. This ensures that when the input has an endAdornment, it reserves 48px of space on the right side for the icon.