### PR TITLE
chore: update lamp-core from 2025.06.04 to 2025.06.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsonata": "^1.8.4",
     "jsonexport": "^3.2.0",
     "jspdf": "^3.0.1",
-    "lamp-core": "2025.06.04",
+    "lamp-core": "2025.06.18",
     "material-icons": "^1.10.11",
     "monaco-editor": "^0.33.0",
     "notistack": "^2.0.5",


### PR DESCRIPTION
Chore: Updating `LAMP-js\lamp-core` SDK to investigate potential version mismatch causing JWT authentication failures between dashboard and server.