### PR TITLE
Local Development Improvements: Setup instructions and http compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ build-storybook.log
 build
 storybook-static
 .env
+
+# Editor config files
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 [To learn more about the LAMP Platform, visit our documentation.](https://docs.lamp.digital/)
 
-## Setup For Local Development
 
+## Local development
 1. Run `npm install`
 2. Make sure that the server you plan on using during development accepts the url of the local dashboard server as 
 an allowed cors origin.
-3. Run `npm start dev`
+3. Start the server:
+
+    If you are using the dashboard to connect to a LAMP-server running locally run: `npm run dev`
+    This will cause the dashboard to make requests to the LAMP-server over http instead of https.
+    
+    If you are using the dashboard to connect to a LAMP-server running elsewhere, or one that is running locally with https enabled run: `npm start`.
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # LAMP Dashboard
 
 [To learn more about the LAMP Platform, visit our documentation.](https://docs.lamp.digital/)
+
+## Setup For Local Development
+
+1. Run `npm install`
+2. Make sure that the server you plan on using during development accepts the url of the local dashboard server as 
+an allowed cors origin.
+3. Run `npm start dev`

--- a/buildEnv.js
+++ b/buildEnv.js
@@ -67,6 +67,7 @@ function writeFile() {
                 `REACT_APP_GIT_SHA=${description}`,
                 `REACT_APP_LATEST_LAMP=${latest}`,
                 isDev ? "BROWSER=none" : "CI=false",
+                `USE_HTTPS=${isDev ? false : true}`,
               ].join("\r\n")
             )
               .then(() => resolve(true))

--- a/buildEnv.js
+++ b/buildEnv.js
@@ -67,7 +67,7 @@ function writeFile() {
                 `REACT_APP_GIT_SHA=${description}`,
                 `REACT_APP_LATEST_LAMP=${latest}`,
                 isDev ? "BROWSER=none" : "CI=false",
-                `USE_HTTPS=${isDev ? false : true}`,
+                `REACT_APP_USE_HTTPS=${isDev ? false : true}`,
               ].join("\r\n")
             )
               .then(() => resolve(true))

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "scripts": {
     "preinstall": "npx npm-force-resolutions",
+    "dev": "node buildEnv dev && react-scripts start",
     "start": "node buildEnv prod && react-scripts start",
     "start-sw": "http-server -p 3000 ./build",
     "test": "echo \"no tests configured\"",

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -19,6 +19,7 @@ import useInterval from "./useInterval"
 import LAMP from "lamp-core"
 import { useTranslation } from "react-i18next"
 import { Alert } from "@mui/material"
+import { buildLampServerRequestUrl } from "../utilities"
 const useStyles = makeStyles((theme) => ({
   conversationStyle: {
     borderRadius: "10px",
@@ -132,7 +133,7 @@ const useStyles = makeStyles((theme) => ({
 }))
 
 const fetchCoordinators = async (participant) => {
-  const baseUrl = "https://" + (!!LAMP.Auth._auth.serverAddress ? LAMP.Auth._auth.serverAddress : "api.lamp.digital")
+  const baseUrl = buildLampServerRequestUrl(LAMP.Auth._auth.serverAddress || "api.lamp.digital")
   const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
   let result = await (
     await fetch(`${baseUrl}/${participant}/cordinators`, {

--- a/src/components/Researcher/SaveResearcherData.tsx
+++ b/src/components/Researcher/SaveResearcherData.tsx
@@ -12,7 +12,7 @@ interface StudyObject {
   sensors: Array<any>
 }
 export const fetchResult = async (id, type, modal) => {
-  const baseUrl = "http://" + (!!LAMP.Auth._auth.serverAddress ? LAMP.Auth._auth.serverAddress : "api.lamp.digital")
+  const baseUrl = buildLampServerRequestUrl(LAMP.Auth._auth.serverAddress || "api.lamp.digital")
   const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
   let result = await (
     await fetch(`${baseUrl}/${modal}/${id}/_lookup/${type}`, {

--- a/src/components/Researcher/SaveResearcherData.tsx
+++ b/src/components/Researcher/SaveResearcherData.tsx
@@ -1,6 +1,7 @@
 import { Service } from "../DBService/DBService"
 import demo_db from "../../demo_db.json"
 import LAMP from "lamp-core"
+import { buildLampServerRequestUrl } from "../../utilities"
 
 interface StudyObject {
   id: string
@@ -11,7 +12,7 @@ interface StudyObject {
   sensors: Array<any>
 }
 export const fetchResult = async (id, type, modal) => {
-  const baseUrl = "https://" + (!!LAMP.Auth._auth.serverAddress ? LAMP.Auth._auth.serverAddress : "api.lamp.digital")
+  const baseUrl = "http://" + (!!LAMP.Auth._auth.serverAddress ? LAMP.Auth._auth.serverAddress : "api.lamp.digital")
   const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
   let result = await (
     await fetch(`${baseUrl}/${modal}/${id}/_lookup/${type}`, {
@@ -27,7 +28,7 @@ export const fetchResult = async (id, type, modal) => {
 }
 
 export const fetchPostData = async (id, type, modal, methodType, bodyData) => {
-  const baseUrl = "https://" + (!!LAMP.Auth._auth.serverAddress ? LAMP.Auth._auth.serverAddress : "api.lamp.digital")
+  const baseUrl = buildLampServerRequestUrl(LAMP.Auth._auth.serverAddress || "api.lamp.digital")
   const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
   let result = await (
     await fetch(`${baseUrl}/${modal}/${id}/${type}`, {

--- a/src/components/data_portal/DataPortalHome.tsx
+++ b/src/components/data_portal/DataPortalHome.tsx
@@ -21,6 +21,7 @@ import Editor from "./Editor"
 import jsonata from "jsonata"
 import { useDrop } from "react-dnd"
 import { useTranslation } from "react-i18next"
+import { buildLampServerRequestUrl } from "../../utilities"
 
 export default function DataPortalHome({ token, onLogout, ...props }) {
   const classes = portalHomeStyle()
@@ -45,7 +46,7 @@ export default function DataPortalHome({ token, onLogout, ...props }) {
     try {
       jsonata(query)["errors"] // check for errors first (change from .errors() made for TSX compliance)
       const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
-      let res = await fetch(`https://${token.server}`, {
+      let res = await fetch(buildLampServerRequestUrl(token.server), {
         method: "POST",
         headers: {
           Authorization: `Bearer ${userToken.accessToken}`,

--- a/src/components/data_portal/DataPortalShared.tsx
+++ b/src/components/data_portal/DataPortalShared.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { createStyles, makeStyles, Theme } from "@material-ui/core"
 import LAMP from "lamp-core"
+import { buildLampServerRequestUrl } from "../../utilities"
 
 export function useLocalStorage(key, initialValue) {
   const [storedValue, setStoredValue] = React.useState(() => {
@@ -56,7 +57,7 @@ export function ajaxRequest(parameters) {
 export const jsonataFetch = async (query, access_key, secret_key, server) => {
   try {
     const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
-    let res = await fetch(`https://${server}`, {
+    let res = await fetch(buildLampServerRequestUrl(server), {
       method: "POST",
       headers: {
         Authorization: `Bearer ${userToken.accessToken}`,

--- a/src/components/data_portal/QueryBuilder.tsx
+++ b/src/components/data_portal/QueryBuilder.tsx
@@ -29,6 +29,7 @@ import { useTranslation } from "react-i18next"
 import { useDrop } from "react-dnd"
 import SelectionWindow from "./SelectionWindow"
 import LAMP from "lamp-core"
+import { buildLampServerRequestUrl } from "../../utilities"
 
 const useStyles = makeStyles((theme) => ({
   loadingBackdrop: {
@@ -170,13 +171,14 @@ export default function QueryBuilder(props) {
     setSelectedSharedTags([])
     setSharedTags([])
     setLoadingStatuses(false)
+    const baseUrl = buildLampServerRequestUrl(props.token.server)
     if (props.focusMe && typeof props.focusMe === "function") props.focusMe()
     props.setQueryResult("")
     if (currentQuery.target.length !== 0) {
       let testQuery = `$LAMP.Tag.list('${currentQuery.target}')`
       let tagSending = {
         method: "POST",
-        url: `https://${props.token.server}/`,
+        url: baseUrl,
         headers: [["Authorization", `Bearer ${userToken.accessToken}`]],
         data: testQuery,
         callback: function (res) {
@@ -192,7 +194,7 @@ export default function QueryBuilder(props) {
         ].toLowerCase()}_tags'))`
         let sharedSending = {
           method: "POST",
-          url: `https://${props.token.server}/`,
+          url: baseUrl,
           headers: [["Authorization", `Bearer ${userToken.accessToken}`]],
           data: sharedQuery,
           callback: function (res) {
@@ -229,7 +231,7 @@ export default function QueryBuilder(props) {
 
       let sending = {
         method: "POST",
-        url: `https://${props.token.server}/`,
+        url: buildLampServerRequestUrl(props.token.server),
         headers: [["Authorization", `Bearer ${userToken.accessToken}`]],
         data: tagQuery,
         callback: function (res) {
@@ -383,7 +385,7 @@ export default function QueryBuilder(props) {
 
           let sending = {
             method: "POST",
-            url: `https://${props.token.server}/`,
+            url: buildLampServerRequestUrl(props.token.server),
             headers: [["Authorization", `Bearer ${userToken.accessToken}`]],
             data: tagQuery,
             callback: function (res) {

--- a/src/components/data_portal/RenderTree.tsx
+++ b/src/components/data_portal/RenderTree.tsx
@@ -32,6 +32,7 @@ import { saveAs } from "file-saver"
 import * as jsonexport from "jsonexport/dist"
 import { useTranslation } from "react-i18next"
 import { getSelfHelpAllActivityEvents } from "../Participant"
+import { buildLampServerRequestUrl } from "../../utilities"
 
 export default function RenderTree({ id, type, token, name, onSetQuery, onUpdateGUI, isGUIEditor, ...props }) {
   const [treeDisplay, setTree] = React.useState(null)
@@ -158,7 +159,7 @@ export default function RenderTree({ id, type, token, name, onSetQuery, onUpdate
   const getData = async (query) => {
     try {
       const userToken: any = JSON.parse(sessionStorage.getItem("tokenInfo"))
-      let res = await fetch(`https://${token.server}`, {
+      let res = await fetch(buildLampServerRequestUrl(token.server), {
         method: "POST",
         headers: {
           Authorization: `Bearer ${userToken.accessToken}`,

--- a/src/components/data_portal/SignIn.tsx
+++ b/src/components/data_portal/SignIn.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Typography, Button, Icon, TextField, Container, Avatar, makeStyles } from "@material-ui/core"
 import { ajaxRequest } from "./DataPortalShared"
 import { useTranslation } from "react-i18next"
+import { buildLampServerRequestUrl } from "../../utilities"
 
 const useStyles = makeStyles((theme) => ({
   paper: {
@@ -55,7 +56,7 @@ export default function SignIn({ onSubmit, ...props }) {
           let sending = {
             method: "GET",
             //@ts-ignore: This property will be created by the form (see line 37)
-            url: `https://${data.server}/researcher/me`,
+            url: buildLampServerRequestUrl(data.server, "/researcher/me"),
             //@ts-ignore: This property will be created by the form (see line 37)
             headers: [["Authorization", `Bearer ${userToken.accessToken}`]],
             callback: readyUser,
@@ -95,7 +96,7 @@ export default function SignIn({ onSubmit, ...props }) {
     let sending = {
       method: "GET",
       //@ts-ignore: This property will be created by the form (see line 37)
-      url: `https://${data.server}/type/me/parent`,
+      url: buildLampServerRequestUrl(data.server, "/type/me/parent"),
       //@ts-ignore: This property will be created by the form (see line 37)
       headers: [["Authorization", `Bearer ${userToken.accessToken}`]],
       callback: setUser,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -49,6 +49,11 @@ input, textarea, .contenteditable, .lamp-editable *, .swagger-ui * {
   }
   ;(window.CustomEvent as any) = CustomEvent
 })()
+
+if (process.env.USE_HTTPS) {
+  LAMP.enableDevMode()
+}
+
 // Initialize the demo DB for "Try It" mode.
 // Tie-in for the mobile apps.
 // Login only if we are a participant.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,7 +50,9 @@ input, textarea, .contenteditable, .lamp-editable *, .swagger-ui * {
   ;(window.CustomEvent as any) = CustomEvent
 })()
 
-if (process.env.USE_HTTPS) {
+// Enable lamp-core's dev mode in order to make server requests over http
+console.log(process.env, process.env.USE_HTTPS)
+if (process.env.REACT_APP_USE_HTTPS === "false") {
   LAMP.enableDevMode()
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -51,7 +51,6 @@ input, textarea, .contenteditable, .lamp-editable *, .swagger-ui * {
 })()
 
 // Enable lamp-core's dev mode in order to make server requests over http
-console.log(process.env, process.env.USE_HTTPS)
 if (process.env.REACT_APP_USE_HTTPS === "false") {
   LAMP.enableDevMode()
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,4 @@
+export function buildLampServerRequestUrl(lampServerUrl: string, path?: "") {
+  const protocol = process.env.USE_HTTPS === "true" ? "https://" : "http://"
+  return `${protocol}${lampServerUrl.replace(/\/$/, "")}/${path?.replace(/^\//, "") || ""}`
+}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,4 +1,6 @@
+// Use the correct protocol to make requests to the LAMP-server
+// Default to using https
 export function buildLampServerRequestUrl(lampServerUrl: string, path?: "") {
-  const protocol = process.env.USE_HTTPS === "true" ? "https://" : "http://"
+  const protocol = process.env.REACT_APP_USE_HTTPS === "false" ? "http://" : "https://"
   return `${protocol}${lampServerUrl.replace(/\/$/, "")}/${path?.replace(/^\//, "") || ""}`
 }


### PR DESCRIPTION
This pr adds documentation for local set, and the ability to connect to a server using `http` instead of `https`.

This pr relies on [this change](https://github.com/BIDMCDigitalPsychiatry/LAMP-js/pull/64) to LAMP-js. We should merge this one after the LAMP-js change.