### PR TITLE
Fix PREDiCTOR gateway card API hostname

### DIFF
--- a/src/components/ServerGateway.tsx
+++ b/src/components/ServerGateway.tsx
@@ -41,7 +41,7 @@ export const KNOWN_SERVERS: ServerOption[] = [
     name: "PREDiCTOR",
     description: "Mount Sinai Health System",
     logo: PredictorLogo,
-    apiServerUrl: "api.mshai.org",
+    apiServerUrl: "api.mindlamp.mshai.org",
   },
   {
     name: "LevelUp",


### PR DESCRIPTION
`api.mshai.org` does not resolve (NXDOMAIN). The PREDiCTOR LAMP server is at `api.mindlamp.mshai.org`, so selecting the PREDiCTOR card could never reach a server.

Participants have been logging in successfully via "connect to a different server" with the correct address, which confirms basic auth negotiates fine against that server despite it returning 404 api-endpoint-unimplemented for /server-info. The card path calls the same `LAMP.Auth.set_server()`, so the corrected hostname takes an already-proven route.

Wrong since `2be75971` lifted the gateway onto the session-auth branch; the card has never worked, so this is not a regression.