### PR TITLE
Fix group creation failing silently on a malformed request URL

### DIFF
--- a/src/components/Researcher/SaveResearcherData.tsx
+++ b/src/components/Researcher/SaveResearcherData.tsx
@@ -29,7 +29,7 @@ export const fetchResult = async (id, type, modal, authorizationHeader) => {
 export const fetchPostData = async (id, type, modal, methodType, bodyData, authorizationHeader) => {
   const baseUrl = buildLampServerRequestUrl(LAMP.Auth._auth.serverAddress || "api.lamp.digital")
   let result = await (
-    await fetch(`${baseUrl}/${modal}/${id}/${type}`, {
+    await fetch(composeRequestPath([baseUrl, modal, id, type]), {
       method: methodType,
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
fetchPostData built its URL by concatenating a slash onto the value returned by buildLampServerRequestUrl, which already ends in one. Every POST therefore went to a double-slashed path:

  `https://<server>//researcher/<id>/study/clone`

Express does not collapse the duplicate slash, so the request 404s with {"message": "404.api-endpoint-unimplemented"}. That body is valid JSON, so .json() resolves, no error is thrown, and PatientStudyCreator carries on with an undefined study id: it writes a phantom row into the local IndexedDB cache, closes the dialog, and shows no error. The group is never created on the server and disappears on reload.

fetchResult, ten lines above in the same file, was migrated to composeRequestPath when that helper was introduced; fetchPostData was missed. Use the same helper here.

fetchPostData has exactly one caller in the codebase -- creating a group from the Groups tab -- which is why no other group operation regressed. Rename, delete, and the Users-tab "Add a new group" entry point all go through lamp-core and were unaffected.