### PR TITLE
Add FAVORITES_ENABLED flag and fix the TabList crash it exposed

### DIFF
--- a/src/components/ActivityAccordian.tsx
+++ b/src/components/ActivityAccordian.tsx
@@ -13,6 +13,7 @@ import {
 } from "@material-ui/core"
 import InfoIcon from "../icons/Info.svg"
 import LAMP from "lamp-core"
+import { FAVORITES_ENABLED } from "../featureFlags"
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     favstar: {
@@ -196,7 +197,7 @@ const moduleAccordianContent = (module, classes, tag, favoriteIds, handleFavorit
           <Box>
             <Box display="flex" alignItems="center">
               <Typography variant="h6">{module.name}</Typography>
-              {module.name !== "Other activities" && (
+              {FAVORITES_ENABLED && module.name !== "Other activities" && (
                 <Tooltip
                   title={
                     favoriteIds.includes(module.id)
@@ -258,6 +259,7 @@ const ActivityAccordion = ({ data, type, tag, handleSubModule, participant, setF
   const [favoriteIds, setFavoriteIds] = useState<string[]>([])
 
   useEffect(() => {
+    if (!FAVORITES_ENABLED) return
     ;(async () => {
       let tag =
         [await LAMP.Type.getAttachment(participant?.id, "lamp.dashboard.favorite_activities")].map((y: any) =>
@@ -268,6 +270,7 @@ const ActivityAccordion = ({ data, type, tag, handleSubModule, participant, setF
   }, [])
 
   const handleFavoriteClick = async (activityId: string) => {
+    if (!FAVORITES_ENABLED) return
     try {
       const result: any = await LAMP.Type.getAttachment(participant?.id, "lamp.dashboard.favorite_activities")
       let tag: string[] = !!result.error ? [] : result.data ?? []

--- a/src/components/ActivityBox.tsx
+++ b/src/components/ActivityBox.tsx
@@ -7,7 +7,7 @@ import { ReactComponent as JournalIcon } from "../icons/Goal.svg"
 import InfoIcon from "../icons/Info.svg"
 import ScratchCard from "../icons/ScratchCard.svg"
 import { activityIcons } from "../icons/activities"
-import { MODULES_ENABLED } from "../featureFlags"
+import { FAVORITES_ENABLED, MODULES_ENABLED } from "../featureFlags"
 import { useTranslation } from "react-i18next"
 import ActivityPopup from "./ActivityPopup"
 import ReactMarkdown from "react-markdown"
@@ -596,13 +596,15 @@ export default function ActivityBox({ type, savedActivities, tag, participant, s
     }
     localStorage.removeItem("moduleId")
     localStorage.removeItem("lastAnsweredIndex")
-    ;(async () => {
-      let tag =
-        [await LAMP.Type.getAttachment(participant.id, "lamp.dashboard.favorite_activities")].map((y: any) =>
-          !!y.error ? undefined : y.data
-        )[0] ?? []
-      setFavorites((savedActivities || []).filter((activity) => tag.includes(activity.id)))
-    })()
+    if (FAVORITES_ENABLED) {
+      ;(async () => {
+        let tag =
+          [await LAMP.Type.getAttachment(participant.id, "lamp.dashboard.favorite_activities")].map((y: any) =>
+            !!y.error ? undefined : y.data
+          )[0] ?? []
+        setFavorites((savedActivities || []).filter((activity) => tag.includes(activity.id)))
+      })()
+    }
     setShownActivities(savedActivities)
 
     const runAsync = async () => {
@@ -662,7 +664,9 @@ export default function ActivityBox({ type, savedActivities, tag, participant, s
   useEffect(() => {
     if (localStorage.getItem("tab")) {
       const savedTab = localStorage.getItem("tab")
-      setTab(!MODULES_ENABLED && savedTab === "modules" ? "other" : savedTab)
+      const isHiddenTab =
+        (!MODULES_ENABLED && savedTab === "modules") || (!FAVORITES_ENABLED && savedTab === "favorite")
+      setTab(isHiddenTab ? "other" : savedTab)
       setTimeout(() => {
         localStorage.removeItem("tab")
       }, 1000)
@@ -699,7 +703,7 @@ export default function ActivityBox({ type, savedActivities, tag, participant, s
   }
 
   useEffect(() => {
-    if (tab === "favorite") {
+    if (FAVORITES_ENABLED && tab === "favorite") {
       ;(async () => {
         let tag =
           [await LAMP.Type.getAttachment(participant?.id, "lamp.dashboard.favorite_activities")].map((y: any) =>
@@ -720,9 +724,11 @@ export default function ActivityBox({ type, savedActivities, tag, participant, s
           <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
             {(favorites || []).length > 0 ? (
               <TabList onChange={(e, val) => setTab(val)} className={classes.tabHeader}>
-                <Tab label="Favorites" value="favorite" />
-                {MODULES_ENABLED && <Tab label="Modules" value="modules" />}
-                <Tab label="Other Activities" value="other" />
+                {[
+                  <Tab key="favorite" label="Favorites" value="favorite" />,
+                  MODULES_ENABLED ? <Tab key="modules" label="Modules" value="modules" /> : null,
+                  <Tab key="other" label="Other Activities" value="other" />,
+                ].filter(Boolean)}
               </TabList>
             ) : (
               <TabList onChange={(e, val) => setTab(val)} className={classes.tabHeader}>
@@ -905,7 +911,7 @@ export default function ActivityBox({ type, savedActivities, tag, participant, s
                     }}
                     className={classes.thumbMain}
                   >
-                    {(favorites || []).filter((f) => f?.id == activity?.id).length > 0 && (
+                    {FAVORITES_ENABLED && (favorites || []).filter((f) => f?.id == activity?.id).length > 0 && (
                       <Icon className={classes.favstar}>star_rounded</Icon>
                     )}
 

--- a/src/components/ActivityBox.tsx
+++ b/src/components/ActivityBox.tsx
@@ -590,7 +590,7 @@ export default function ActivityBox({ type, savedActivities, tag, participant, s
     localStorage.removeItem("parentStringForSurvey")
     for (let i = localStorage.length - 1; i >= 0; i--) {
       const key = localStorage.key(i)
-      if (key.startsWith("activity-survey-")) {
+      if (key?.startsWith("activity-survey-")) {
         localStorage.removeItem(key)
       }
     }

--- a/src/components/ActivityListForModule.tsx
+++ b/src/components/ActivityListForModule.tsx
@@ -26,6 +26,7 @@ import { ReactComponent as JournalIcon } from "../icons/Goal.svg"
 import emoji from "remark-emoji"
 import gfm from "remark-gfm"
 import LAMP from "lamp-core"
+import { FAVORITES_ENABLED } from "../featureFlags"
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -349,7 +350,7 @@ const renderActivities = (type, tag, favorites, handleClickOpen, handleSubModule
               }}
               className={classes.thumbMain}
             >
-              {(favorites || []).filter((f) => f?.id == activity?.id).length > 0 && (
+              {FAVORITES_ENABLED && (favorites || []).filter((f) => f?.id == activity?.id).length > 0 && (
                 <Icon className={classes.favstar}>star_rounded</Icon>
               )}
               <ButtonBase focusRipple className={classes.fullwidthBtn}>
@@ -430,6 +431,7 @@ export default function ActivityListForModule({ ...props }) {
   const [favoriteIds, setFavoriteIds] = useState<string[]>([])
 
   useEffect(() => {
+    if (!FAVORITES_ENABLED) return
     // Fetch favorite activities for the participant
     ;(async () => {
       const tag: string[] =
@@ -457,6 +459,7 @@ export default function ActivityListForModule({ ...props }) {
   }
 
   const handleFavoriteClick = async (activityId: string) => {
+    if (!FAVORITES_ENABLED) return
     try {
       const result: any = await LAMP.Type.getAttachment(participant, "lamp.dashboard.favorite_activities")
       let tag: string[] = !!result.error ? [] : result.data ?? []
@@ -495,17 +498,19 @@ export default function ActivityListForModule({ ...props }) {
                 <Grid item>
                   <Box display="flex" alignItems="center">
                     <Typography variant="h6">{module.name}</Typography>
-                    <Fab
-                      className={`${classes.headerTitleIcon} ${
-                        (favorites || []).filter((f) => f == module?.id).length > 0 ? "active" : ""
-                      }`}
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        handleFavoriteClick(module.id)
-                      }}
-                    >
-                      <Icon>star_rounded</Icon>
-                    </Fab>
+                    {FAVORITES_ENABLED && (
+                      <Fab
+                        className={`${classes.headerTitleIcon} ${
+                          (favorites || []).filter((f) => f == module?.id).length > 0 ? "active" : ""
+                        }`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          handleFavoriteClick(module.id)
+                        }}
+                      >
+                        <Icon>star_rounded</Icon>
+                      </Fab>
+                    )}
                   </Box>
                 </Grid>
               </Grid>

--- a/src/components/ActivityPopup.tsx
+++ b/src/components/ActivityPopup.tsx
@@ -35,6 +35,7 @@ import ResponsiveDialog from "./ResponsiveDialog"
 import LAMP from "lamp-core"
 import { isMobile } from "react-device-detect"
 import { useSnackbar } from "notistack"
+import { FAVORITES_ENABLED } from "../featureFlags"
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -241,6 +242,7 @@ export default function ActivityPopup({
   }, [activity])
 
   useEffect(() => {
+    if (!FAVORITES_ENABLED) return
     ;(async () => {
       let tag =
         [await LAMP.Type.getAttachment(participant?.id, "lamp.dashboard.favorite_activities")].map((y: any) =>
@@ -251,6 +253,7 @@ export default function ActivityPopup({
   }, [])
 
   const handleFavoriteClick = async (activityId) => {
+    if (!FAVORITES_ENABLED) return
     try {
       const result: any = await LAMP.Type.getAttachment(participant?.id, "lamp.dashboard.favorite_activities")
       let tag: string[] = !!result.error ? [] : result.data ?? []
@@ -269,7 +272,7 @@ export default function ActivityPopup({
   }
 
   const handleCloseActivityPopup = (activity) => {
-    if (activity?.spec === "lamp.group" && tab === "favorite") {
+    if (FAVORITES_ENABLED && activity?.spec === "lamp.group" && tab === "favorite") {
       ;(async () => {
         let tag =
           [await LAMP.Type.getAttachment(participant?.id, "lamp.dashboard.favorite_activities")].map((y: any) =>
@@ -382,7 +385,7 @@ export default function ActivityPopup({
                 remarkPlugins={[gfm, emoji]}
                 components={{ link: LinkRenderer }}
               />
-              {activity?.spec === "lamp.group" && (
+              {FAVORITES_ENABLED && activity?.spec === "lamp.group" && (
                 <Tooltip
                   title={
                     favoriteIds.includes(activity.id)

--- a/src/components/EmbeddedActivity.tsx
+++ b/src/components/EmbeddedActivity.tsx
@@ -21,6 +21,7 @@ import { Service } from "./DBService/DBService"
 import ResponsiveDialog from "./ResponsiveDialog"
 import ModuleActivity from "./ModuleActivity"
 import NotificationPage from "./NotificationPage"
+import { FAVORITES_ENABLED } from "../featureFlags"
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     backdrop: {
@@ -243,6 +244,10 @@ export default function EmbeddedActivity({
   }, [iFrame])
 
   const updateFavorite = async (data) => {
+    if (!FAVORITES_ENABLED) {
+      delete data.static_data?.is_favorite
+      return data
+    }
     if (typeof data?.static_data?.is_favorite !== undefined) {
       let tag = favoriteActivities
       if (!!data?.static_data?.is_favorite) {
@@ -336,7 +341,7 @@ export default function EmbeddedActivity({
         autoCorrect: !(exist === "true"),
         noBack: noBack,
         forward: props?.forward ?? false,
-        is_favorite: (favoriteActivities || []).filter((t) => t == currentActivity.id).length > 0,
+        is_favorite: FAVORITES_ENABLED && (favoriteActivities || []).filter((t) => t == currentActivity.id).length > 0,
         activeTab: lastActiveTab,
       })
       let activitySpec = await LAMP.ActivitySpec.view(currentActivity.spec)

--- a/src/components/EmbeddedActivity.tsx
+++ b/src/components/EmbeddedActivity.tsx
@@ -443,8 +443,8 @@ export default function EmbeddedActivity({
         onClose={() => {
           setOpen(false)
           localStorage.removeItem("activityFromModule")
-          const response =
-            typeof localStorage.getItem("response") != "undefined" ? JSON.parse(localStorage.getItem("response")) : null
+          const stored = localStorage.getItem("response")
+          const response = stored ? JSON.parse(stored) : null
           if (response) {
             handleSaveData({ data: response })
           }

--- a/src/components/EmbeddedActivity.tsx
+++ b/src/components/EmbeddedActivity.tsx
@@ -248,7 +248,7 @@ export default function EmbeddedActivity({
       delete data.static_data?.is_favorite
       return data
     }
-    if (typeof data?.static_data?.is_favorite !== undefined) {
+    if (typeof data?.static_data?.is_favorite !== "undefined") {
       let tag = favoriteActivities
       if (!!data?.static_data?.is_favorite) {
         if ((tag || []).filter((t) => t == data.activity).length === 0) {

--- a/src/components/GroupActivity.tsx
+++ b/src/components/GroupActivity.tsx
@@ -18,6 +18,7 @@ import { useTranslation } from "react-i18next"
 import { sensorEventUpdate } from "./BottomMenu"
 import { spliceActivity, spliceCTActivity } from "./Researcher/ActivityList/ActivityMethods"
 import { Service } from "./DBService/DBService"
+import { FAVORITES_ENABLED } from "../featureFlags"
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -89,13 +90,19 @@ export default function GroupActivity({ participant, activity, noBack, tab, ...p
   }, [groupActivities])
 
   useEffect(() => {
-    ;(async () => {
-      let tag =
-        [await LAMP.Type.getAttachment(participant, "lamp.dashboard.favorite_activities")].map((y: any) =>
-          !!y?.error ? undefined : y?.data
-        )[0] ?? []
-      setFavoriteActivities(tag)
-    })()
+    // NOTE: the effect above gates on this being non-null, so set an empty
+    // list rather than leaving it unset when favorites are off.
+    if (FAVORITES_ENABLED) {
+      ;(async () => {
+        let tag =
+          [await LAMP.Type.getAttachment(participant, "lamp.dashboard.favorite_activities")].map((y: any) =>
+            !!y?.error ? undefined : y?.data
+          )[0] ?? []
+        setFavoriteActivities(tag)
+      })()
+    } else {
+      setFavoriteActivities([])
+    }
     LAMP.Activity.view(activity.id).then((data) => {
       setIndex(-1)
       if (Array.isArray(data.settings)) {

--- a/src/components/ModuleActivity.tsx
+++ b/src/components/ModuleActivity.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mui/material"
 import ResponsiveDialog from "./ResponsiveDialog"
 import ActivityListForModule from "./ActivityListForModule"
+import { FAVORITES_ENABLED } from "../featureFlags"
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     backdrop: {
@@ -373,6 +374,7 @@ const ModuleActivity = ({ ...props }) => {
 
   const [favorites, setFavorites] = useState([])
   useEffect(() => {
+    if (!FAVORITES_ENABLED) return
     ;(async () => {
       let tag =
         [await LAMP.Type.getAttachment(participant, "lamp.dashboard.favorite_activities")].map((y: any) =>

--- a/src/components/NotificationPage.tsx
+++ b/src/components/NotificationPage.tsx
@@ -26,6 +26,7 @@ import { Service } from "./DBService/DBService"
 import VisualPopup from "./VisualPopup"
 import ModuleActivity from "./ModuleActivity"
 import ResponsiveDialog from "./ResponsiveDialog"
+import { FAVORITES_ENABLED } from "../featureFlags"
 const useStyles = makeStyles((theme) => ({
   root: {
     width: "100%",
@@ -130,6 +131,12 @@ export default function NotificationPage({ participant, activityId, mode, tab, .
   }, [activityId])
 
   useEffect(() => {
+    // NOTE: the effect below gates activity loading on this being non-null, so
+    // set an empty list rather than leaving it unset when favorites are off.
+    if (!FAVORITES_ENABLED) {
+      setFavoriteActivities([])
+      return
+    }
     ;(async () => {
       let tag =
         [await LAMP.Type.getAttachment(participant, "lamp.dashboard.favorite_activities")].map((y: any) =>

--- a/src/components/Researcher/ParticipantList/PatientStudyCreator.tsx
+++ b/src/components/Researcher/ParticipantList/PatientStudyCreator.tsx
@@ -209,7 +209,6 @@ export default function PatientStudyCreator({
   const createStudy = async (studyName: string) => {
     setLoading(true)
     let authId = researcherId
-    let authString = LAMP.Auth._auth.id + ":" + LAMP.Auth._auth.password
     let bodyData = {
       study_id: duplicateStudyName, //old study id
       should_add_participant: createPatient ? createPatient : false,

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -14,8 +14,8 @@ export const MESSAGING_ENABLED = false
 
 // Favorites (the star on activity cards, the Favorites sub-tab, and the
 // favorite toggles in the activity popup and module accordions) arrived on
-// master via the in-flight contractor work and does not function correctly.
-// This flag hides the participant-facing Favorites UI and stops the dashboard
+// master via the in-flight work but is not yet ready for participants. This
+// flag hides the participant-facing Favorites UI and stops the dashboard
 // reading or writing the lamp.dashboard.favorite_activities attachment,
 // without removing any favorites code — flip it back to true to restore it.
 export const FAVORITES_ENABLED = false

--- a/src/featureFlags.ts
+++ b/src/featureFlags.ts
@@ -11,3 +11,11 @@ export const MODULES_ENABLED = false
 // Hides the participant-facing Messages icon (comment badge in the top bar,
 // NavigationLayout). Researcher-side Conversations are NOT gated here.
 export const MESSAGING_ENABLED = false
+
+// Favorites (the star on activity cards, the Favorites sub-tab, and the
+// favorite toggles in the activity popup and module accordions) arrived on
+// master via the in-flight contractor work and does not function correctly.
+// This flag hides the participant-facing Favorites UI and stops the dashboard
+// reading or writing the lamp.dashboard.favorite_activities attachment,
+// without removing any favorites code — flip it back to true to restore it.
+export const FAVORITES_ENABLED = false


### PR DESCRIPTION
Two related changes: a feature flag hiding the Favorites UI, and a fix for the production crash that flag would otherwise have masked rather than resolved.

## The crash
Participants with at least one favorited activity got the full grey "An unexpected error occured" screen when opening **Assess**, on both mobile and desktop. Console:

```
TypeError: Cannot read properties of null (reading 'props')
    at TabList.js:20:50
    at Object.m [as map] (react.production.min.js:17:355)
```

Cause: `ActivityBox.tsx`:

```jsx
<TabList onChange={...}>
  <Tab label="Favorites" value="favorite" />
  {MODULES_ENABLED && <Tab label="Modules" value="modules" />}   {/* → false */}
  <Tab label="Other Activities" value="other" />
</TabList>
```

MUI Lab's `TabList` maps its children with `React.Children.map` and reads `child.props.value`. `React.Children.map` normalizes `false`/`undefined` children to `null` and **still invokes the callback**, so a conditionally-rendered `<Tab>` that evaluates to `false` makes it dereference `null`.

Introduced in `9233b704` ("Hide participant-facing Modules UI behind MODULES_ENABLED flag"), which turned a previously unconditional `<Tab>` into a conditional one. Shipped in `2026.08.05`.

### Why it only hit one person
The tab bar is guarded by `((favorites || []).length > 0 || MODULES_ENABLED)`. With modules off, it renders **only for a participant who has favorited something*. nobody else ever constructs the `TabList`. And `favorites` is computed per-tab, so a favorited *Assess* activity breaks Assess while Learn and Manage stay fine. If favorited activity were on another tab, that tab would be the one that broke.

Confirmed in production: the affected participant's `lamp.dashboard.favorite_activities` attachment returned `200` with a non-empty body, while their `hidden_events` and `hide_activities` both `404`'d in the same page load. The stack trace also points at the `setFavorites(...)` call that populated the array. Their attachment has since been cleared manually, so they are unblocked; this PR stops it recurring.

## The flag
`FAVORITES_ENABLED`, following the existing `MODULES_ENABLED` pattern. Hide the participant-facing UI and stop touching the backing attachment, without removing any favorites code.

Gated:
- the Favorites sub-tab and its panel, and the star badge on activity cards (`ActivityBox`)
- the favorite toggle in the activity popup (`ActivityPopup`), the module accordion (`ActivityAccordian`), and the module activity list (`ActivityListForModule`)
- `is_favorite` in the config posted into activity iframes, and the write-back when an activity returns it (`EmbeddedActivity`)
- every read and write of `lamp.dashboard.favorite_activities`, including the `handleFavoriteClick` handlers. Unreachable from the UI now, but guarded anyway so no code path can write that attachment

## Why both changes 
Gating favorites makes `favorites.length` always `0`, so the tab bar never renders and the crash becomes unreachable. But that is *accidental* protection: flip `FAVORITES_ENABLED` back to `true` while `MODULES_ENABLED` is still `false` and the crash returns immediately. So the underlying defect is fixed too. The children are built as an array with the empty slot filtered out.

All four flag combinations now render correctly:

| FAVORITES | MODULES | Tab bar |
|---|---|---|
| off | off | none (activities render directly) |
| off | on | Modules + Other |
| on | off | Favorites + Other |
| on | on | Favorites + Modules + Other |

## Two edge cases handled
1. **Stale `localStorage["tab"]`**: a participant whose last session left `"favorite"` there would land on a *blank* Assess page now that the panel no longer renders. Falls back to `"other"`, matching the existing handling for `"modules"`.
2. **`NotificationPage` and `GroupActivity` gate activity loading on `!!favoriteActivities`**: skipping the fetch outright would mean activities never load at all. Those set `[]` rather than leaving it `null`.

## Clean up ride-alongs
| Commit | Description |
|---|---|
| `12bf66a0` | Compare typeof against the string in the is_favorite guard |
| `66762b92` | Guard against a null key while sweeping localStorage |
| `79eab060` | Null-check the stored response instead of a typeof guard |
| `e1ade778` | Remove unused authString from the group creator |